### PR TITLE
Minor input fixes

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -20,10 +20,10 @@ const InputFieldComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
         <input
             type="text"
             ref={ref}
-            value={word.toUpperCase()}
+            value={word}
             max={15}
             inputMode="none"
-            onChange={event => setWord(event.target.value)}
+            onChange={event => setWord(event.target.value.toUpperCase())}
             className="h-16 w-80 border-none bg-white
                             text-center text-3xl font-bold
                             text-black caret-primary

--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -18,6 +18,7 @@ const InputFieldComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
 
     return (
         <input
+            autoFocus
             type="text"
             ref={ref}
             value={word}
@@ -29,7 +30,7 @@ const InputFieldComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
                             text-black caret-primary
                             outline-none"
             onKeyDown={keyDown}
-        ></input>
+        />
     );
 };
 


### PR DESCRIPTION
Fixes two things when using the input field to type guesses:
1. A small bug where the last letter in the world wouldn't be uppercased causing no match to be found.
2. Makes sure the input field is automatically focused on page load (might need some tweaking to not trigger on mobile).