### PR TITLE
Always lowercase guessed word

### DIFF
--- a/src/components/InputField.tsx
+++ b/src/components/InputField.tsx
@@ -24,10 +24,10 @@ const InputFieldComponent: ForwardRefRenderFunction<HTMLInputElement, Props> = (
             value={word}
             max={15}
             inputMode="none"
-            onChange={event => setWord(event.target.value.toUpperCase())}
+            onChange={event => setWord(event.target.value.toLowerCase())}
             className="h-16 w-80 border-none bg-white
                             text-center text-3xl font-bold
-                            text-black caret-primary
+                            uppercase text-black caret-primary
                             outline-none"
             onKeyDown={keyDown}
         />


### PR DESCRIPTION
Instead of uppercasing the guessed word with JS, always lowercase it (since that's what the wordlist contains) and let CSS handle the rest.